### PR TITLE
Data Sync Trigger

### DIFF
--- a/.github/workflows/send-data.yml
+++ b/.github/workflows/send-data.yml
@@ -1,0 +1,23 @@
+name: Trigger Sync with Data Repo
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'data/**'
+
+env:
+  ORG_NAME: openelections # Who ownes the repo?
+  REPO_NAME: openelections-data-la  # What repo should we notify?
+
+jobs:
+  trigger-workflow:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Repository Dispatch
+      uses: peter-evans/repository-dispatch@v2
+      with:
+        token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        repository: ${{ env.ORG_NAME }}/${{ env.REPO_NAME }}
+        event-type: import-data-trigger


### PR DESCRIPTION
Whenever there is a change in the /data directory, a notification is sent to the openelections-data-la repo initiating a raw data import.

Waiting to merge this into main until I set the `PERSONAL_ACCESS_TOKEN` secret in this repo.